### PR TITLE
run: add support for BUILD_SCRIPT argument

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,8 @@ jobs:
       - name: Build Arch Linux package
         uses: FFY00/build-arch-package@master
         with:
+          BUILD_SCRIPT: extra-x86_64-build
           PKGBUILD: $GITHUB_WORKSPACE/.github/workflows/PKGBUILD
           OUTDIR: $HOME/arch-packages
 
+# See: https://github.com/taotieren/deepin-wine-qq-arch/blob/master/.github/workflows/main.yml

--- a/README.md
+++ b/README.md
@@ -24,9 +24,22 @@ See [.github/workflows/test.yml](.github/workflows/test.yml) for a working examp
 
 ### Arguments
 
-Key        | Description                                 | Required | Default Value
----------- | ------------------------------------------- |:--------:| -------------
-`PKGBUILD` | PKGBUILD path                               | **Yes**  |
-`OUTDIR`   | Output directory to store the built package | No       | `$HOME/arch-packages`
+Key            | Description                                 | Required | Default Value
+-------------- | ------------------------------------------- |:--------:| -------------
+`PKGBUILD`     | PKGBUILD path                               | **Yes**  |
+`BUILD_SCRIPT` | Pacman configuration file used              | No       | `extra-x86_64-build`
+`OUTDIR`       | Output directory to store the built package | No       | `$HOME/arch-packages`
+
+
+See：[DeveloperWiki:Building_in_a_clean_chroot](https://wiki.archlinux.org/index.php/DeveloperWiki:Building_in_a_clean_chroot)
+
+Target repository         | Architecture | Build script to use    | Pacman configuration file used
+-------------------------:|-------------:|-----------------------:|-------------------------------
+extra/community           | x86_64       | extra-x86_64-build     | /usr/share/devtools/pacman-extra.conf
+testing/community-testing | x86_64       | testing-x86_64-build   | /usr/share/devtools/pacman-testing.conf
+staging/community-staging | x86_64       | staging-x86_64-build   | /usr/share/devtools/pacman-staging.conf
+multilib                  | x86_64       | multilib-build         | /usr/share/devtools/pacman-multilib.conf
+multilib-testing          | x86_64       | multilib-testing-build | /usr/share/devtools/pacman-multilib-testing.conf
+multilib-staging          | x86_64       | multilib-staging-build | /usr/share/devtools/pacman-multilib-staging.conf
 
 ###### You can use environment variable names in the options, they will be resolved.

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: Output directory to store the built package (relative to $HOME)
     required: false
     default: $HOME/arch-packages
+  BUILD_SCRIPT:
+    description: Pacman configuration file used
+    required: false
+    deafult: extra-x86_64-build
 branding:
   color: blue
   icon: archive

--- a/run.sh
+++ b/run.sh
@@ -1,24 +1,23 @@
 #!/bin/bash -ex
 
-if [ -z "$INPUT_PKGBUILD" ] || [ -z "$INPUT_OUTDIR" ] || [ -z "$GITHUB_SHA" ]; then
+if [ -z "$INPUT_BUILD_SCRIPT" ] || [ -z "$INPUT_PKGBUILD" ] || [ -z "$INPUT_OUTDIR" ] || [ -z "$GITHUB_SHA" ]; then
     echo 'Missing environment variables'
     exit 1
 fi
 
 # Resolve environment paths
+INPUT_BUILD_SCRIPT="$(eval echo $INPUT_BUILD_SCRIPT)"
 INPUT_PKGBUILD="$(eval echo $INPUT_PKGBUILD)"
 INPUT_OUTDIR="$(eval echo $INPUT_OUTDIR)"
 
 # Get PKGBUILD dir
 PKGBUILD_DIR=$(dirname $(readlink -f $INPUT_PKGBUILD))
 
-# Prepare the environment
 pacman -Syu --noconfirm --noprogressbar --needed base-devel devtools btrfs-progs dbus sudo
 
 dbus-uuidgen --ensure=/etc/machine-id
 
 sed -i "s|MAKEFLAGS=.*|MAKEFLAGS=-j$(nproc)|" /etc/makepkg.conf
-
 useradd -m user
 cd /home/user
 
@@ -28,7 +27,8 @@ sed "s|%COMMIT%|$GITHUB_SHA|" "$INPUT_PKGBUILD" > PKGBUILD
 chown user PKGBUILD
 
 # Build the package
-extra-x86_64-build -- -U user
+# See：https://wiki.archlinux.org/index.php/DeveloperWiki:Building_in_a_clean_chroot
+"$INPUT_BUILD_SCRIPT" -- -U user
 
 # Save the artifacts
 mkdir -p "$INPUT_OUTDIR"


### PR DESCRIPTION
This patch adds support for `BUILD_SCRIPT` argument in the action, providing
the ability to use different scripts other than `extra-x86_64-build`. For
backward compatibility, this argument is optional, using `extra-x86_64-build`
by default.