### PR TITLE
github: use the current repository and commit hash

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build Arch Linux package
-        uses: FFY00/build-arch-package@master
+        uses: ./
         with:
           BUILD_SCRIPT: extra-x86_64-build
           PKGBUILD: $GITHUB_WORKSPACE/.github/workflows/PKGBUILD


### PR DESCRIPTION
This patch is required to test the action properly, being able to run the
correct changes rather than relying on changes in the `master` branch.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>